### PR TITLE
Add VS Code launch configuration for regression script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run regression.py",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/regression.py",
+            "console": "integratedTerminal",
+            "args": [
+                "${input:csvPath}"
+            ]
+        }
+    ],
+    "inputs": [
+        {
+            "id": "csvPath",
+            "type": "promptString",
+            "description": "Đường dẫn đến tệp CSV chứa các cột 'sat' và 'colgpa'",
+            "default": "path/to/data.csv"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# M-h-nh-h-i-quy-n-gi-n
+# Mô hình hồi quy tuyến tính đơn
+
+Dự án này cung cấp một script Python (`regression.py`) để ước lượng mô hình hồi quy tuyến tính đơn giữa điểm SAT và GPA đại học.
+
+## Cài đặt
+
+Script yêu cầu Python 3.8+ cùng với các thư viện phụ thuộc:
+
+```bash
+pip install pandas scikit-learn
+```
+
+## Sử dụng
+
+### Chạy trực tiếp trong VS Code
+
+1. Mở thư mục dự án trong VS Code.
+2. Đảm bảo đã cài đặt tiện ích mở rộng **Python** của Microsoft.
+3. Mở tab **Run and Debug** (hoặc nhấn `Ctrl+Shift+D`) và chọn cấu hình **Run regression.py**.
+4. Nhấn **Start Debugging** (`F5`). VS Code sẽ yêu cầu bạn nhập đường dẫn tới tệp CSV chứa dữ liệu với hai cột bắt buộc: `sat` và `colgpa`.
+5. Sau khi cung cấp đường dẫn và nhấn Enter, script sẽ chạy trong terminal tích hợp của VS Code.
+
+Nếu một trong hai cột bị thiếu, chương trình sẽ hiển thị thông báo lỗi mô tả rõ cột nào còn thiếu.
+
+### Chạy bằng dòng lệnh
+
+Bạn cũng có thể chạy script trong terminal nếu muốn:
+
+```bash
+python regression.py path/to/data.csv
+```
+
+### Ví dụ
+
+```bash
+python regression.py data/college_scores.csv
+```
+
+Đầu ra bao gồm hệ số chặn, hệ số góc (slope), hệ số xác định R² và một diễn giải ngắn gọn về ý nghĩa của hệ số góc.

--- a/regression.py
+++ b/regression.py
@@ -1,0 +1,81 @@
+"""Simple linear regression analysis for SAT and college GPA data."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+
+REQUIRED_COLUMNS = {"sat", "colgpa"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fit a simple linear regression model predicting college GPA from SAT scores "
+            "using data from a CSV file."
+        )
+    )
+    parser.add_argument(
+        "csv_path",
+        type=Path,
+        help="Path to the CSV file containing 'sat' and 'colgpa' columns.",
+    )
+    return parser.parse_args()
+
+
+def load_data(csv_path: Path) -> pd.DataFrame:
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    data = pd.read_csv(csv_path)
+    missing = REQUIRED_COLUMNS.difference(data.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise ValueError(
+            "The input file must contain the following columns: 'sat' and 'colgpa'. "
+            f"Missing columns: {missing_cols}"
+        )
+
+    return data
+
+
+def run_regression(data: pd.DataFrame) -> None:
+    X = data[["sat"]]
+    y = data["colgpa"]
+
+    model = LinearRegression()
+    model.fit(X, y)
+
+    coefficient = float(model.coef_[0])
+    intercept = float(model.intercept_)
+    r_squared = float(model.score(X, y))
+
+    print("Linear Regression Results")
+    print("--------------------------")
+    print(f"Intercept: {intercept:.4f}")
+    print(f"Slope (SAT coefficient): {coefficient:.4f}")
+    print(f"R-squared: {r_squared:.4f}")
+    print()
+    print(
+        "Interpretation: For each additional point increase in SAT, the model "
+        f"predicts an average change of {coefficient:.4f} in college GPA."
+    )
+
+
+def main() -> None:
+    args = parse_args()
+
+    try:
+        data = load_data(args.csv_path)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    run_regression(data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a VS Code launch configuration to run regression.py with a prompted CSV path
- update the README with step-by-step instructions for running the script directly inside VS Code while keeping CLI usage notes

## Testing
- not run (dependencies such as pandas/scikit-learn are not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e304ca44e48329b59d8f7344f46695